### PR TITLE
Check for dependencies and warn on missing ones.

### DIFF
--- a/fm.awk
+++ b/fm.awk
@@ -1,5 +1,4 @@
 #!/usr/bin/awk -f
-
 BEGIN {
 
     ###################
@@ -84,7 +83,6 @@ END {
         printf("%s", dir) > "/dev/stdout"; close("/dev/stdout")
         printf("%s", dir) > LASTPATH; close(LASTPATH)
     }
-    print "\n"
 }
 
 function main() {

--- a/fm.awk
+++ b/fm.awk
@@ -33,6 +33,10 @@ BEGIN {
         cmd = aliasarr[line]; gsub(/.*=/, "", cmd); gsub(/^'|'$/, "", cmd)
         cmdalias[key] = cmd
     }
+    # Check dependencies
+    DEP_CHAFA    = program_exists("chafa")               #Check for chafa for general image display.
+    DEP_PDFTOPPM = program_exists("pdftoppm")            #Check for pdftoppm for PDF previews.
+    DEP_FFMPEGTH = program_exists("ffmpegthumbnailer")   #Check for ffmpegthumbnailer for video previews.
 
     #############
     #  Actions  #
@@ -80,6 +84,7 @@ END {
         printf("%s", dir) > "/dev/stdout"; close("/dev/stdout")
         printf("%s", dir) > LASTPATH; close(LASTPATH)
     }
+    print "\n"
 }
 
 function main() {
@@ -793,24 +798,10 @@ function draw_preview(item) {
             print prev[i] >> "/dev/stderr"
         }
     }
-    else if (path ~ /.*\.pdf/) {
+    else if (path ~ /.*\.pdf/) { # Preview PDF file.
         CUP(top, border + 1)
-        cmd = "pdftoppm -jpeg -f 1 -singlefile \"" path "\" 2>/dev/null | chafa -s " 2.5*((end - top) / num) "x \"-\" 2>/dev/null"
-        cmd | getline fig
-        close(cmd)
-        split(fig, prev, "\n")
-        for (i = 1; i <= ((end - top) / num); i++) {
-            CUP(top + i - 1, border + 1)
-            print prev[i] >> "/dev/stderr"
-        }
-    }
-    else if (path ~ /.*\.bmp|.*\.jpg|.*\.jpeg|.*\.png|.*\.xpm|.*\.webp|.*\.gif/) {
-        CUP(top, border + 1)
-        if (path ~ /.*\.gif/) {
-            printf "\033\13338;5;0m\033\13348;5;15m%s\033\133m", "image" >> "/dev/stderr"
-        }
-        else {
-            cmd = "chafa -s " 2.5*((end - top) / num) "x \"" path "\""
+        if (DEP_CHAFA && DEP_PDFTOPPM) {
+            cmd = "pdftoppm -jpeg -f 1 -singlefile \"" path "\" 2>/dev/null | chafa -s " 2.5*((end - top) / num) "x \"-\" 2>/dev/null"
             cmd | getline fig
             close(cmd)
             split(fig, prev, "\n")
@@ -818,20 +809,56 @@ function draw_preview(item) {
                 CUP(top + i - 1, border + 1)
                 print prev[i] >> "/dev/stderr"
             }
+        } else {
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", "Missing dependencies. Cannot preview PDF file." >> "/dev/stderr"
+            CUP(top + 1, border + 1)
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", (DEP_CHAFA)    ? "- chafa   : Y " : "- chafa   : N " >> "/dev/stderr"
+            CUP(top + 2, border + 1)
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", (DEP_PDFTOPPM) ? "- pdftoppm: Y " : "- pdftoppm: N " >> "/dev/stderr"
         }
     }
-    else if (path ~ /.*\.avi|.*\.mp4|.*\.wmv|.*\.dat|.*\.3gp|.*\.ogv|.*\.mkv|.*\.mpg|.*\.mpeg|.*\.vob|.*\.fl[icv]|.*\.m2v|.*\.mov|.*\.webm|.*\.ts|.*\.mts|.*\.m4v|.*\.r[am]|.*\.qt|.*\.divx/) {
+    else if (path ~ /.*\.bmp|.*\.jpg|.*\.jpeg|.*\.png|.*\.xpm|.*\.webp|.*\.gif/) { # Preview image file.
         CUP(top, border + 1)
-        cmd = "ffmpegthumbnailer -i \"" path "\" -o \"-\" -c jpg -s 0 -q 5 2>/dev/null | chafa -s " 2.5*((end - top) / num) "x \"-\" 2>/dev/null"
-        cmd | getline fig
-        close(cmd)
-        split(fig, prev, "\n")
-        for (i = 1; i <= ((end - top) / num); i++) {
-            CUP(top + i - 1, border + 1)
-            print prev[i] >> "/dev/stderr"
+        if (DEP_CHAFA) {
+            if (path ~ /.*\.gif/) {
+                printf "\033\13338;5;0m\033\13348;5;15m%s\033\133m", "image" >> "/dev/stderr"
+            }
+            else {
+                cmd = "chafa -s " 2.5*((end - top) / num) "x \"" path "\""
+                cmd | getline fig
+                close(cmd)
+                split(fig, prev, "\n")
+                for (i = 1; i <= ((end - top) / num); i++) {
+                    CUP(top + i - 1, border + 1)
+                    print prev[i] >> "/dev/stderr"
+                }
+            }
+        } else {
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", "Missing dependencies. Cannot preview image file." >> "/dev/stderr"
+            CUP(top + 1, border + 1)
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", (DEP_CHAFA)    ? "- chafa   : Y " : "- chafa   : N " >> "/dev/stderr"
         }
     }
-    else {
+    else if (path ~ /.*\.avi|.*\.mp4|.*\.wmv|.*\.dat|.*\.3gp|.*\.ogv|.*\.mkv|.*\.mpg|.*\.mpeg|.*\.vob|.*\.fl[icv]|.*\.m2v|.*\.mov|.*\.webm|.*\.ts|.*\.mts|.*\.m4v|.*\.r[am]|.*\.qt|.*\.divx/) { # Preview video file.
+        CUP(top, border + 1)
+        if (DEP_CHAFA && DEP_FFMPEGTH) {
+            cmd = "ffmpegthumbnailer -i \"" path "\" -o \"-\" -c jpg -s 0 -q 5 2>/dev/null | chafa -s " 2.5*((end - top) / num) "x \"-\" 2>/dev/null"
+            cmd | getline fig
+            close(cmd)
+            split(fig, prev, "\n")
+            for (i = 1; i <= ((end - top) / num); i++) {
+                CUP(top + i - 1, border + 1)
+                print prev[i] >> "/dev/stderr"
+            }
+        } else {
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", "Missing dependencies. Cannot preview video file." >> "/dev/stderr"
+            CUP(top + 1, border + 1)
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", (DEP_CHAFA)    ? "- chafa            : Y " : "- chafa            : N " >> "/dev/stderr"
+            CUP(top + 2, border + 1)
+            printf "\033\13338;5;0m\033\13348;5;3m%s\033\133m", (DEP_PDFTOPPM) ? "- ffmpegthumbnailer: Y " : "- ffmpegthumbnailer: N " >> "/dev/stderr"
+        }
+    }
+    else { # Standard file
         getline content < path
         close(path)
         split(content, prev, "\n")
@@ -860,4 +887,12 @@ function notify(msg, str) {
     printf "\033\133?25l" >> "/dev/stderr" # hide cursor
     system("stty -icanon -echo")
     return str
+}
+
+function program_exists(cmd, temp) { #Check if a program exists in $PATH.
+    #Recent (2008+) POSIX specs ( https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html ) specificate this should be a valid method.
+    cmd = "command -v " cmd
+    cmd | getline temp
+    close(cmd)
+    return (length(temp) > 0)
 }


### PR DESCRIPTION
Hello.

As discussed on #1, I made the checks and error messages for missing dependencies, at least for preview-related ones.
This checks for dependencies at BEGIN and checks before attempting to preview a file.
I ended up going with the `command -v` method since the alternative we discussed has the problem of executing a program and gather any output, which could be troublesome if it's a tool that performs an action with no arguments and can incur in load times.
Warning messages will appear as such:
![image](https://user-images.githubusercontent.com/323651/127085590-4070265b-c8ca-41bc-a527-6a2facd91ffb.png)
Please check if it's all in order, tested it with various files but just in case.

Regards.
Magpie