### PR TITLE
Fix broken preview for text files

### DIFF
--- a/fmawk-previewer
+++ b/fmawk-previewer
@@ -15,7 +15,7 @@ batorcat() {
     then
 		bat --color=always --style=plain --pager=never "$1"
 	else
-		cat "$file"
+		cat "$1"
 	fi
 }
 


### PR DESCRIPTION
Currently, previewing text files fails with:

    cat: '': No such file or directory

because "$file" expands to null string.